### PR TITLE
Fix TypeError when submitting w/o SLACK_CHANNELS config

### DIFF
--- a/lib/assets/client.js
+++ b/lib/assets/client.js
@@ -19,7 +19,7 @@ body.addEventListener('submit', function(ev){
   button.disabled = true;
   button.className = '';
   button.innerHTML = 'Please Wait';
-  invite(channel.value, coc && coc.checked ? 1 : 0, email.value, function(err, msg){
+  invite(channel ? channel.value : null, coc && coc.checked ? 1 : 0, email.value, function(err, msg){
     if (err) {
       button.removeAttribute('disabled');
       button.className = 'error';


### PR DESCRIPTION
Introduced with the merge of https://github.com/rauchg/slackin/pull/152/,
the problem was if the `SLACK_CHANNELS` environment variable wasn't set
up, then no hidden form element with the listed channels would be
included. Therefore, our `channel` variable would be `undefined`, and a
direct access of the `value` property would crash the app.

Thanks to @andrewsardone 